### PR TITLE
Update version, contributors, and repo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "highcharts",
   "description": "JavaScript charting framework",
   "homepage": "http://www.highcharts.com",
-  "version": "8.2.2",
+  "version": "8.2.2-lineaje-01",
   "author": "Highsoft AS <support@highcharts.com> (http://www.highcharts.com/about)",
   "main": "highcharts.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/highcharts/highcharts-dist"
+    "url": "https://github.com/lineaje-labs-gos/highcharts-dist"
   },
   "keywords": [
     "charts",
@@ -20,5 +20,11 @@
   ],
   "bugs": "https://github.com/highcharts/highcharts/issues",
   "license": "https://www.highcharts.com/license",
+  "contributors": [
+    {
+      "name": "Lineaje DepFixer",
+      "email": "221268890+Lineaje-DepFixer@users.noreply.github.com"
+    }
+  ],
   "types": "highcharts.d.ts"
 }


### PR DESCRIPTION
- Appended '-lineaje-01' to the version.
- Updated repository URL to point to the new repourl in lineaje-labs-gos
